### PR TITLE
Fix kibana entrypoint

### DIFF
--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -1,3 +1,8 @@
 FROM kibana:4.5.1
 
+RUN apt-get update              \
+ && apt-get install -y netcat   \
+ && apt-get clean               \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 COPY ./docker-entrypoint.sh /


### PR DESCRIPTION
- container now waits for Elasticsearch HTTP API to be available,
  instead of crashing.
- use wget instead of curl which is not provided by the base
  Docker image anymore.

Fixes #1
